### PR TITLE
좋아요 취소 시 컬럼이 하나 더 생기는 버그 수정

### DIFF
--- a/src/main/java/com/mfc/batch/batch/application/JobScheduler.java
+++ b/src/main/java/com/mfc/batch/batch/application/JobScheduler.java
@@ -25,7 +25,7 @@ public class JobScheduler {
 	private final JobLauncher jobLauncher;
 	private final Job postBookmarkJob;
 
-	@Scheduled(cron = "0 */3 * * * *")
+	@Scheduled(cron = "0 */1 * * * *")
 	public void jobSchedule() throws
 			JobInstanceAlreadyCompleteException,
 			JobExecutionAlreadyRunningException,


### PR DESCRIPTION
## 📣 좋아요 취소 시 같은 postId를 가지는 컬럼이 하나 더 생기는 버그 수정
### 📅(날짜 -  YYYY.MM.DD)
 
 ### 🌵Branch
`develop`  → `feature/fix-bug`

### 📢 Description
- 좋아요 취소 시 같은 postId를 가지는 컬럼이 하나 더 생기는 버그 수정
- 배치 스케줄러 실행 간격 변경 : 3분 → 1분

### 💬Issue Number

### 🛠️Type
- [ ] 새로운 기능 추가 
- [x] 버그 수정 
- [ ] CSS 등 사용자 UI 디자인 변경 
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경) 
- [x] 코드 리팩토링 
- [ ] 주석 추가 및 수정 
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링 
- [ ] 빌드 부분 혹은 패키지 매니저 수정 
- [ ] 파일 혹은 폴더명 수정 
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist 
PR이 다음 요구 사항을 충족하는지 확인하세요. 
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note

