### PR TITLE
파트너 집계 데이터 조회 및 랭킹 구현

### DIFF
--- a/src/main/java/com/mfc/batch/batch/application/BatchService.java
+++ b/src/main/java/com/mfc/batch/batch/application/BatchService.java
@@ -8,6 +8,6 @@ import com.mfc.batch.batch.dto.resp.PostSummaryRespDto;
 
 public interface BatchService {
 	PostSummaryRespDto getBookmarkCnt(Long postId);
-	PartnerRankingRespDto getPartnerRanking(Pageable page);
+	PartnerRankingRespDto getPartnerRanking();
 	PartnerSummaryRespDto getPartnerSummary(String uuid);
 }

--- a/src/main/java/com/mfc/batch/batch/application/BatchService.java
+++ b/src/main/java/com/mfc/batch/batch/application/BatchService.java
@@ -3,9 +3,11 @@ package com.mfc.batch.batch.application;
 import org.springframework.data.domain.Pageable;
 
 import com.mfc.batch.batch.dto.resp.PartnerRankingRespDto;
+import com.mfc.batch.batch.dto.resp.PartnerSummaryRespDto;
 import com.mfc.batch.batch.dto.resp.PostSummaryRespDto;
 
 public interface BatchService {
 	PostSummaryRespDto getBookmarkCnt(Long postId);
 	PartnerRankingRespDto getPartnerRanking(Pageable page);
+	PartnerSummaryRespDto getPartnerSummary(String uuid);
 }

--- a/src/main/java/com/mfc/batch/batch/application/BatchService.java
+++ b/src/main/java/com/mfc/batch/batch/application/BatchService.java
@@ -1,7 +1,9 @@
 package com.mfc.batch.batch.application;
 
+import com.mfc.batch.batch.dto.resp.PartnerRankingRespDto;
 import com.mfc.batch.batch.dto.resp.PostSummaryRespDto;
 
 public interface BatchService {
 	PostSummaryRespDto getBookmarkCnt(Long postId);
+	PartnerRankingRespDto getPartnerRanking();
 }

--- a/src/main/java/com/mfc/batch/batch/application/BatchService.java
+++ b/src/main/java/com/mfc/batch/batch/application/BatchService.java
@@ -1,9 +1,11 @@
 package com.mfc.batch.batch.application;
 
+import org.springframework.data.domain.Pageable;
+
 import com.mfc.batch.batch.dto.resp.PartnerRankingRespDto;
 import com.mfc.batch.batch.dto.resp.PostSummaryRespDto;
 
 public interface BatchService {
 	PostSummaryRespDto getBookmarkCnt(Long postId);
-	PartnerRankingRespDto getPartnerRanking();
+	PartnerRankingRespDto getPartnerRanking(Pageable page);
 }

--- a/src/main/java/com/mfc/batch/batch/application/BatchServiceImpl.java
+++ b/src/main/java/com/mfc/batch/batch/application/BatchServiceImpl.java
@@ -2,6 +2,8 @@ package com.mfc.batch.batch.application;
 
 import static com.mfc.batch.common.response.BaseResponseStatus.*;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -41,14 +43,13 @@ public class BatchServiceImpl implements BatchService {
 	}
 
 	@Override
-	public PartnerRankingRespDto getPartnerRanking(Pageable page) {
-		Slice<PartnerRanking> ranking = partnerRankingRepository.findAll(page);
+	public PartnerRankingRespDto getPartnerRanking() {
+		List<PartnerRanking> ranking = partnerRankingRepository.findAll();
 
 		return PartnerRankingRespDto.builder()
-				.partners(ranking.getContent().stream()
+				.partners(ranking.stream()
 						.map(PartnerSummaryRespDto::new)
 						.toList())
-				.isLast(ranking.isLast())
 				.build();
 	}
 

--- a/src/main/java/com/mfc/batch/batch/application/BatchServiceImpl.java
+++ b/src/main/java/com/mfc/batch/batch/application/BatchServiceImpl.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.mfc.batch.batch.domain.PartnerRanking;
+import com.mfc.batch.batch.domain.PartnerSummary;
 import com.mfc.batch.batch.domain.PostSummary;
 import com.mfc.batch.batch.dto.resp.PartnerRankingRespDto;
 import com.mfc.batch.batch.dto.resp.PartnerSummaryRespDto;
@@ -48,6 +49,19 @@ public class BatchServiceImpl implements BatchService {
 						.map(PartnerSummaryRespDto::new)
 						.toList())
 				.isLast(ranking.isLast())
+				.build();
+	}
+
+	@Override
+	public PartnerSummaryRespDto getPartnerSummary(String uuid) {
+		PartnerSummary summary = partnerSummaryRepository.findByPartnerId(uuid)
+				.orElseThrow(() -> new BaseException(PARTNER_NOT_FOUND));
+
+		return PartnerSummaryRespDto.builder()
+				.partnerId(uuid)
+				.coordinateCnt(summary.getCoordinateCnt())
+				.followerCnt(summary.getFollowerCnt())
+				.averageStar(summary.getAverageStar())
 				.build();
 	}
 }

--- a/src/main/java/com/mfc/batch/batch/application/BatchServiceImpl.java
+++ b/src/main/java/com/mfc/batch/batch/application/BatchServiceImpl.java
@@ -2,10 +2,13 @@ package com.mfc.batch.batch.application;
 
 import static com.mfc.batch.common.response.BaseResponseStatus.*;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.mfc.batch.batch.domain.PartnerRanking;
 import com.mfc.batch.batch.domain.PostSummary;
 import com.mfc.batch.batch.dto.resp.PartnerRankingRespDto;
 import com.mfc.batch.batch.dto.resp.PartnerSummaryRespDto;
@@ -38,10 +41,13 @@ public class BatchServiceImpl implements BatchService {
 
 	@Override
 	public PartnerRankingRespDto getPartnerRanking(Pageable page) {
+		Slice<PartnerRanking> ranking = partnerRankingRepository.findAll(page);
+
 		return PartnerRankingRespDto.builder()
-				.partners(partnerRankingRepository.findAll(page).stream()
+				.partners(ranking.getContent().stream()
 						.map(PartnerSummaryRespDto::new)
 						.toList())
+				.isLast(ranking.isLast())
 				.build();
 	}
 }

--- a/src/main/java/com/mfc/batch/batch/application/BatchServiceImpl.java
+++ b/src/main/java/com/mfc/batch/batch/application/BatchServiceImpl.java
@@ -2,7 +2,7 @@ package com.mfc.batch.batch.application;
 
 import static com.mfc.batch.common.response.BaseResponseStatus.*;
 
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,9 +37,9 @@ public class BatchServiceImpl implements BatchService {
 	}
 
 	@Override
-	public PartnerRankingRespDto getPartnerRanking() {
+	public PartnerRankingRespDto getPartnerRanking(Pageable page) {
 		return PartnerRankingRespDto.builder()
-				.partners(partnerRankingRepository.findAll().stream()
+				.partners(partnerRankingRepository.findAll(page).stream()
 						.map(PartnerSummaryRespDto::new)
 						.toList())
 				.build();

--- a/src/main/java/com/mfc/batch/batch/application/BatchServiceImpl.java
+++ b/src/main/java/com/mfc/batch/batch/application/BatchServiceImpl.java
@@ -2,11 +2,16 @@ package com.mfc.batch.batch.application;
 
 import static com.mfc.batch.common.response.BaseResponseStatus.*;
 
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.mfc.batch.batch.domain.PostSummary;
+import com.mfc.batch.batch.dto.resp.PartnerRankingRespDto;
+import com.mfc.batch.batch.dto.resp.PartnerSummaryRespDto;
 import com.mfc.batch.batch.dto.resp.PostSummaryRespDto;
+import com.mfc.batch.batch.infrastructure.PartnerRankingRepository;
+import com.mfc.batch.batch.infrastructure.PartnerSummaryRepository;
 import com.mfc.batch.batch.infrastructure.PostSummaryRepository;
 import com.mfc.batch.common.exception.BaseException;
 
@@ -14,9 +19,11 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class BatchServiceImpl implements BatchService {
 	private final PostSummaryRepository postSummaryRepository;
+	private final PartnerSummaryRepository partnerSummaryRepository;
+	private final PartnerRankingRepository partnerRankingRepository;
 
 	@Override
 	public PostSummaryRespDto getBookmarkCnt(Long postId) {
@@ -26,6 +33,15 @@ public class BatchServiceImpl implements BatchService {
 		return PostSummaryRespDto.builder()
 				.postId(postId)
 				.bookmarkCnt(summary.getBookmarkCnt())
+				.build();
+	}
+
+	@Override
+	public PartnerRankingRespDto getPartnerRanking() {
+		return PartnerRankingRespDto.builder()
+				.partners(partnerRankingRepository.findAll().stream()
+						.map(PartnerSummaryRespDto::new)
+						.toList())
 				.build();
 	}
 }

--- a/src/main/java/com/mfc/batch/batch/application/JobScheduler.java
+++ b/src/main/java/com/mfc/batch/batch/application/JobScheduler.java
@@ -1,6 +1,8 @@
 package com.mfc.batch.batch.application;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
@@ -9,7 +11,15 @@ import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.mfc.batch.batch.domain.PartnerRanking;
+import com.mfc.batch.batch.domain.PartnerSummary;
+import com.mfc.batch.batch.infrastructure.PartnerRankingRepository;
+import com.mfc.batch.batch.infrastructure.PartnerSummaryRepository;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -20,12 +30,19 @@ public class JobScheduler {
 	private final Job postSummaryJob;
 	private final Job partnerSummaryJob;
 
+	private final PartnerSummaryRepository partnerSummaryRepository;
+	private final PartnerRankingRepository partnerRankingRepository;
+
 	public JobScheduler(JobLauncher jobLauncher,
 			@Qualifier("postSummaryJob") Job postBookmarkJob,
-			@Qualifier("partnerSummaryJob") Job partnerJobConfig) {
+			@Qualifier("partnerSummaryJob") Job partnerJobConfig,
+			PartnerSummaryRepository partnerSummaryRepository,
+			PartnerRankingRepository partnerRankingRepository) {
 		this.jobLauncher = jobLauncher;
 		this.postSummaryJob = postBookmarkJob;
 		this.partnerSummaryJob = partnerJobConfig;
+		this.partnerSummaryRepository = partnerSummaryRepository;
+		this.partnerRankingRepository = partnerRankingRepository;
 	}
 
 	@Scheduled(cron = "0 */1 * * * *")
@@ -46,5 +63,28 @@ public class JobScheduler {
 				.toJobParameters();
 
 		JobExecution postJob = jobLauncher.run(partnerSummaryJob, jobParameters);
+	}
+
+	@Scheduled(cron = "0 0 * * * *")
+	@Transactional
+	public void partnerRanking() {
+		partnerRankingRepository.deleteAll();
+
+		Pageable pageable = PageRequest.of(0, 30);
+		List<PartnerSummary> partners = partnerSummaryRepository.findPartnerRank(pageable);
+
+		int rank = 1;
+		List<PartnerRanking> ranking = new ArrayList<>();
+		for (PartnerSummary partner : partners) {
+			ranking.add(PartnerRanking.builder()
+					.ranking(rank++)
+					.partnerId(partner.getPartnerId())
+					.coordinateCnt(partner.getCoordinateCnt())
+					.followerCnt(partner.getFollowerCnt())
+					.averageStar(partner.getAverageStar())
+					.build());
+		}
+
+		partnerRankingRepository.saveAll(ranking);
 	}
 }

--- a/src/main/java/com/mfc/batch/batch/application/PartnerJobConfig.java
+++ b/src/main/java/com/mfc/batch/batch/application/PartnerJobConfig.java
@@ -97,7 +97,7 @@ public class PartnerJobConfig {
 	public ItemProcessor<PartnerProfileDto, PartnerSummary> partnerSummaryProcessor() {
 		return dto -> {
 			PartnerSummary summary = partnerSummaryRepository.findByPartnerId(dto.getPartnerId())
-					.orElseThrow(() -> new BaseException(BaseResponseStatus.POST_NOT_FOUND));
+					.orElseThrow(() -> new BaseException(BaseResponseStatus.PARTNER_NOT_FOUND));
 
 			return PartnerSummary.builder()
 						.id(summary.getId())

--- a/src/main/java/com/mfc/batch/batch/domain/PartnerRanking.java
+++ b/src/main/java/com/mfc/batch/batch/domain/PartnerRanking.java
@@ -1,0 +1,38 @@
+package com.mfc.batch.batch.domain;
+
+import org.hibernate.annotations.BatchSize;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@BatchSize(size = 50)
+public class PartnerRanking {
+	@Id
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "ranking_seq")
+	@SequenceGenerator(name = "ranking_seq", sequenceName = "ranking_seq", allocationSize = 30)
+	private Long id;
+	private Integer ranking;
+	private String partnerId;
+	private Double averageStar;
+	private Integer coordinateCnt;
+	private Integer followerCnt;
+
+	@Builder
+	public PartnerRanking(Integer ranking, String partnerId, Double averageStar, Integer coordinateCnt,
+			Integer followerCnt) {
+		this.ranking = ranking;
+		this.partnerId = partnerId;
+		this.averageStar = averageStar;
+		this.coordinateCnt = coordinateCnt;
+		this.followerCnt = followerCnt;
+	}
+}

--- a/src/main/java/com/mfc/batch/batch/dto/resp/PartnerRankingRespDto.java
+++ b/src/main/java/com/mfc/batch/batch/dto/resp/PartnerRankingRespDto.java
@@ -9,5 +9,4 @@ import lombok.Getter;
 @Builder
 public class PartnerRankingRespDto {
 	private List<PartnerSummaryRespDto> partners;
-	private Boolean isLast;
 }

--- a/src/main/java/com/mfc/batch/batch/dto/resp/PartnerRankingRespDto.java
+++ b/src/main/java/com/mfc/batch/batch/dto/resp/PartnerRankingRespDto.java
@@ -9,4 +9,5 @@ import lombok.Getter;
 @Builder
 public class PartnerRankingRespDto {
 	private List<PartnerSummaryRespDto> partners;
+	private Boolean isLast;
 }

--- a/src/main/java/com/mfc/batch/batch/dto/resp/PartnerRankingRespDto.java
+++ b/src/main/java/com/mfc/batch/batch/dto/resp/PartnerRankingRespDto.java
@@ -1,0 +1,12 @@
+package com.mfc.batch.batch.dto.resp;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PartnerRankingRespDto {
+	private List<PartnerSummaryRespDto> partners;
+}

--- a/src/main/java/com/mfc/batch/batch/dto/resp/PartnerSummaryRespDto.java
+++ b/src/main/java/com/mfc/batch/batch/dto/resp/PartnerSummaryRespDto.java
@@ -1,0 +1,21 @@
+package com.mfc.batch.batch.dto.resp;
+
+import com.mfc.batch.batch.domain.PartnerRanking;
+import com.mfc.batch.batch.domain.PartnerSummary;
+
+import lombok.Getter;
+
+@Getter
+public class PartnerSummaryRespDto {
+	private String partnerId;
+	private Integer followerCnt;
+	private Integer coordinateCnt;
+	private Double averageStar;
+
+	public PartnerSummaryRespDto(PartnerRanking ranking) {
+		this.partnerId = ranking.getPartnerId();
+		this.followerCnt = ranking.getFollowerCnt();
+		this.coordinateCnt = ranking.getCoordinateCnt();
+		this.averageStar = ranking.getAverageStar();
+	}
+}

--- a/src/main/java/com/mfc/batch/batch/dto/resp/PartnerSummaryRespDto.java
+++ b/src/main/java/com/mfc/batch/batch/dto/resp/PartnerSummaryRespDto.java
@@ -3,9 +3,15 @@ package com.mfc.batch.batch.dto.resp;
 import com.mfc.batch.batch.domain.PartnerRanking;
 import com.mfc.batch.batch.domain.PartnerSummary;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class PartnerSummaryRespDto {
 	private String partnerId;
 	private Integer followerCnt;

--- a/src/main/java/com/mfc/batch/batch/infrastructure/PartnerRankingRepository.java
+++ b/src/main/java/com/mfc/batch/batch/infrastructure/PartnerRankingRepository.java
@@ -1,0 +1,13 @@
+package com.mfc.batch.batch.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import com.mfc.batch.batch.domain.PartnerRanking;
+
+public interface PartnerRankingRepository extends JpaRepository<PartnerRanking, Long> {
+	@Modifying
+	@Query("DELETE FROM PartnerRanking pr")
+	void deleteAll();
+}

--- a/src/main/java/com/mfc/batch/batch/infrastructure/PartnerSummaryRepository.java
+++ b/src/main/java/com/mfc/batch/batch/infrastructure/PartnerSummaryRepository.java
@@ -1,12 +1,18 @@
 package com.mfc.batch.batch.infrastructure;
 
+import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.mfc.batch.batch.domain.PartnerSummary;
-import com.mfc.batch.batch.domain.PostSummary;
 
 public interface PartnerSummaryRepository extends JpaRepository<PartnerSummary, Long> {
 	Optional<PartnerSummary> findByPartnerId(String partnerId);
+
+	@Query("SELECT ps FROM PartnerSummary ps " +
+			"ORDER BY (ps.followerCnt * 0.4 + ps.coordinateCnt * 0.3 + ps.averageStar * 0.3) DESC")
+	List<PartnerSummary> findPartnerRank(Pageable page);
 }

--- a/src/main/java/com/mfc/batch/batch/presentation/BatchController.java
+++ b/src/main/java/com/mfc/batch/batch/presentation/BatchController.java
@@ -1,16 +1,23 @@
 package com.mfc.batch.batch.presentation;
 
+import static com.mfc.batch.common.response.BaseResponseStatus.*;
+
 import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.Pageable;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.mfc.batch.batch.application.BatchService;
 import com.mfc.batch.batch.vo.resp.PartnerRankingRespVo;
+import com.mfc.batch.batch.vo.resp.PartnerSummaryRespVo;
 import com.mfc.batch.batch.vo.resp.PostSummaryRespVo;
+import com.mfc.batch.common.exception.BaseException;
 import com.mfc.batch.common.response.BaseResponse;
+import com.mfc.batch.common.response.BaseResponseStatus;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -36,5 +43,20 @@ public class BatchController {
 	public BaseResponse<PartnerRankingRespVo> getPartnerRanking(Pageable page) {
 		return new BaseResponse<>(modelMapper.map(
 				batchService.getPartnerRanking(page), PartnerRankingRespVo.class));
+	}
+
+	@GetMapping("/partners/summary")
+	@Operation(summary = "파트너 집계 데이터 조회 API", description = "팔로워 수, 코디 매칭 수, 평균 별점")
+	public BaseResponse<PartnerSummaryRespVo> getPartnerSummary(
+			@RequestHeader(value = "partnerId", defaultValue = "") String partnerId) {
+		checkUuid(partnerId);
+		return new BaseResponse<>(modelMapper.map(
+				batchService.getPartnerSummary(partnerId), PartnerSummaryRespVo.class));
+	}
+
+	private void checkUuid(String uuid) throws BaseException {
+		if(!StringUtils.hasText(uuid)) {
+			throw new BaseException(NO_REQUIRED_HEADER);
+		}
 	}
 }

--- a/src/main/java/com/mfc/batch/batch/presentation/BatchController.java
+++ b/src/main/java/com/mfc/batch/batch/presentation/BatchController.java
@@ -40,9 +40,9 @@ public class BatchController {
 
 	@GetMapping("/ranking")
 	@Operation(summary = "파트너 랭킹 목록 조회 API", description = "파트너 랭킹 목록 조회 (id + 기준값)")
-	public BaseResponse<PartnerRankingRespVo> getPartnerRanking(Pageable page) {
+	public BaseResponse<PartnerRankingRespVo> getPartnerRanking() {
 		return new BaseResponse<>(modelMapper.map(
-				batchService.getPartnerRanking(page), PartnerRankingRespVo.class));
+				batchService.getPartnerRanking(), PartnerRankingRespVo.class));
 	}
 
 	@GetMapping("/partners/summary")

--- a/src/main/java/com/mfc/batch/batch/presentation/BatchController.java
+++ b/src/main/java/com/mfc/batch/batch/presentation/BatchController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.mfc.batch.batch.application.BatchService;
+import com.mfc.batch.batch.vo.resp.PartnerRankingRespVo;
 import com.mfc.batch.batch.vo.resp.PostSummaryRespVo;
 import com.mfc.batch.common.response.BaseResponse;
 
@@ -27,5 +28,12 @@ public class BatchController {
 	public BaseResponse<PostSummaryRespVo> getBookmarkCnt(@PathVariable Long postId) {
 		return new BaseResponse<>(modelMapper.map(
 				batchService.getBookmarkCnt(postId), PostSummaryRespVo.class));
+	}
+
+	@GetMapping("/ranking")
+	@Operation(summary = "파트너 랭킹 목록 조회 API", description = "파트너 랭킹 목록 조회 (id + 기준값)")
+	public BaseResponse<PartnerRankingRespVo> getPartnerRanking() {
+		return new BaseResponse<>(modelMapper.map(
+				batchService.getPartnerRanking(), PartnerRankingRespVo.class));
 	}
 }

--- a/src/main/java/com/mfc/batch/batch/presentation/BatchController.java
+++ b/src/main/java/com/mfc/batch/batch/presentation/BatchController.java
@@ -1,6 +1,7 @@
 package com.mfc.batch.batch.presentation;
 
 import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,8 +33,8 @@ public class BatchController {
 
 	@GetMapping("/ranking")
 	@Operation(summary = "파트너 랭킹 목록 조회 API", description = "파트너 랭킹 목록 조회 (id + 기준값)")
-	public BaseResponse<PartnerRankingRespVo> getPartnerRanking() {
+	public BaseResponse<PartnerRankingRespVo> getPartnerRanking(Pageable page) {
 		return new BaseResponse<>(modelMapper.map(
-				batchService.getPartnerRanking(), PartnerRankingRespVo.class));
+				batchService.getPartnerRanking(page), PartnerRankingRespVo.class));
 	}
 }

--- a/src/main/java/com/mfc/batch/batch/vo/resp/PartnerRankingRespVo.java
+++ b/src/main/java/com/mfc/batch/batch/vo/resp/PartnerRankingRespVo.java
@@ -7,5 +7,4 @@ import lombok.Getter;
 @Getter
 public class PartnerRankingRespVo {
 	private List<PartnerSummaryRespVo> partners;
-	private Boolean isLast;
 }

--- a/src/main/java/com/mfc/batch/batch/vo/resp/PartnerRankingRespVo.java
+++ b/src/main/java/com/mfc/batch/batch/vo/resp/PartnerRankingRespVo.java
@@ -7,4 +7,5 @@ import lombok.Getter;
 @Getter
 public class PartnerRankingRespVo {
 	private List<PartnerSummaryRespVo> partners;
+	private Boolean isLast;
 }

--- a/src/main/java/com/mfc/batch/batch/vo/resp/PartnerRankingRespVo.java
+++ b/src/main/java/com/mfc/batch/batch/vo/resp/PartnerRankingRespVo.java
@@ -1,0 +1,10 @@
+package com.mfc.batch.batch.vo.resp;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class PartnerRankingRespVo {
+	private List<PartnerSummaryRespVo> partners;
+}

--- a/src/main/java/com/mfc/batch/batch/vo/resp/PartnerSummaryRespVo.java
+++ b/src/main/java/com/mfc/batch/batch/vo/resp/PartnerSummaryRespVo.java
@@ -1,0 +1,11 @@
+package com.mfc.batch.batch.vo.resp;
+
+import lombok.Getter;
+
+@Getter
+public class PartnerSummaryRespVo {
+	private String partnerId;
+	private Integer followerCnt;
+	private Integer coordinateCnt;
+	private Double averageStar;
+}

--- a/src/main/java/com/mfc/batch/common/response/BaseResponseStatus.java
+++ b/src/main/java/com/mfc/batch/common/response/BaseResponseStatus.java
@@ -16,7 +16,8 @@ public enum BaseResponseStatus {
 	SUCCESS(HttpStatus.OK, true, 200, "요청에 성공했습니다."),
 
 	POST_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 포스팅입니다."),
-	PARTNER_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 파트너입니다.");
+	PARTNER_NOT_FOUND(HttpStatus.NOT_FOUND, false, 404, "존재하지 않는 파트너입니다."),
+	NO_REQUIRED_HEADER(HttpStatus.BAD_REQUEST, false, 400, "헤더에 UUID 혹은 Role이 존재하지 않습니다.");
 
 
 	private final HttpStatusCode httpStatusCode;


### PR DESCRIPTION
## 📣 파트너 집계 데이터 조회 및 랭킹 구현
### 📅 2024.06.27
 
 ### 🌵Branch
`feature/partner-ranking` → `develop`

### 📢 Description
- 파트너 집계 데이터 조회 API 구현
- 파트너 랭킹 갱신 로직 구현 (스케줄러)
  - 1시간에 한 번 + 30명
  - 팔로워 수 → 코디 매칭 수 → 평균 별점
- 랭킹 목록 반환 API 구현 

### 💬Issue Number
close #11 

### 🛠️Type
- [x] 새로운 기능 추가 
- [x] 버그 수정 
- [ ] CSS 등 사용자 UI 디자인 변경 
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경) 
- [x] 코드 리팩토링 
- [ ] 주석 추가 및 수정 
- [ ] 문서 수정 -
- [ ] 테스트 추가, 테스트 리팩토링 
- [ ] 빌드 부분 혹은 패키지 매니저 수정 
- [ ] 파일 혹은 폴더명 수정 
- [ ] 파일 혹은 폴더 삭제

### ✔️PR Checklist 
PR이 다음 요구 사항을 충족하는지 확인하세요. 
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 🔖Note
